### PR TITLE
Add macOS support (Intel and Apple Silicon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Install dependencies via Homebrew before installing ImageMagick:
 
 ```bash
 brew install libpng libjpeg-turbo libtiff webp
+``` 
 
 ### Passing Extra Arguments for configure:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # asdf-imagemagick
 ![GITHUB ACTIONS BADGE](https://github.com/mangalakader/asdf-imagemagick/workflows/Imagemagick%20Plugin%20Test/badge.svg)
 
-## Currently, the plugin works only for Linux based OS.
+## Currently, the plugin works for Linux based OS and macOS
+
+## macOS Prerequisites
+
+Install dependencies via Homebrew before installing ImageMagick:
+
+```bash
+brew install libpng libjpeg-turbo libtiff webp
 
 ### Passing Extra Arguments for configure:
 
@@ -14,5 +21,3 @@ The plugin installation defaults to asdf install directory, which might look lik
 
 If something is wrong, please look for logs in the asdf install dir named
 config.log, make.log, make_install.log
-
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Currently, the plugin works for Linux based OS and macOS
 
-## macOS Prerequisites
+### macOS Prerequisites
 
 Install dependencies via Homebrew before installing ImageMagick:
 

--- a/bin/install
+++ b/bin/install
@@ -5,11 +5,8 @@ install_imagemagick() {
   local version=$2
   local install_path=$3
 
-  if [ "$TMPDIR" = "" ]; then
-    local tmp_download_dir=$(mktemp -d -t imagemagick_build_XXXXXX)
-  else
-    local tmp_download_dir=$TMPDIR
-  fi
+  # Always create a subdirectory to avoid deleting the entire TMPDIR
+  local tmp_download_dir=$(mktemp -d -t imagemagick_build_XXXXXX)
 
   # path to the tar file
   local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
@@ -21,7 +18,13 @@ install_imagemagick() {
   (
     tar zxf $source_path -C $tmp_download_dir --strip-components=1 || exit 1
     cd $tmp_download_dir
-    ./configure --prefix=$ASDF_INSTALL_PATH CPPFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib" $IMAGEMAGICK_EXTRA > $ASDF_INSTALL_PATH/../config.log
+    # Detect Homebrew prefix (Apple Silicon vs Intel)
+    if [ -d "/opt/homebrew" ]; then
+      BREW_PREFIX="/opt/homebrew"
+    else
+      BREW_PREFIX="/usr/local"
+    fi
+    ./configure --prefix=$ASDF_INSTALL_PATH CPPFLAGS="-I$BREW_PREFIX/include" LDFLAGS="-L$BREW_PREFIX/lib" PKG_CONFIG_PATH="$BREW_PREFIX/lib/pkgconfig" $IMAGEMAGICK_EXTRA > $ASDF_INSTALL_PATH/../config.log
     make clean test > $ASDF_INSTALL_PATH/../make.log
     make install > $ASDF_INSTALL_PATH/../make_install.log
     rm -rf $tmp_download_dir


### PR DESCRIPTION
Fixes two issues to enable macOS support:

1. **TMPDIR fix** - Always create a subdirectory with `mktemp -d` to avoid deleting the entire temp folder

2. **Homebrew paths** - Detect `/opt/homebrew` (Apple Silicon) vs `/usr/local` (Intel/Linux)